### PR TITLE
Oss ドキュメント体系化

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 openTiger continuously runs:
 
-1. requirement/issue の取り込み
-2. task の計画と配布
-3. 実装/テスト/ドキュメント更新の実行
+1. requirement/issue ingestion
+2. task planning and dispatch
+3. implementation/testing/documentation updates
 4. review/judgement
 5. recovery/retry/rework
 
@@ -18,7 +18,7 @@ all under explicit runtime state transitions.
   <img src="assets/ui.png" alt="openTiger UI" width="720" />
 </p>
 
-## 主要機能
+## Key Features
 
 - Requirement -> executable task generation
 - Role-based execution (`worker` / `tester` / `docser`)
@@ -28,7 +28,7 @@ all under explicit runtime state transitions.
 - Dashboard + API for process control, logs, and system config
 - Runtime switch between host process and docker sandbox execution
 
-## アーキテクチャ概要
+## Architecture Overview
 
 - **API (`@openTiger/api`)**: system/config/control endpoints and dashboard backend
 - **Planner**: generates tasks from requirements/issues
@@ -40,21 +40,21 @@ all under explicit runtime state transitions.
 
 See `docs/architecture.md` for component-level details.
 
-## 前提環境
+## Prerequisites
 
 - Node.js `>=20`
 - pnpm `9.x`
 - Docker (for local DB/Redis and sandbox execution mode)
 
-## インストール
+## Installation
 
-### 推奨（bootstrap script）
+### Recommended (bootstrap script)
 
 ```bash
 curl -fsSL https://opentiger.dev/install.sh | bash
 ```
 
-### 手動（clone してセットアップ）
+### Manual (clone and setup)
 
 ```bash
 git clone git@github.com:Andyyyy64/openTiger.git
@@ -62,7 +62,7 @@ cd openTiger
 pnpm run setup
 ```
 
-## クイックスタート
+## Quick Start
 
 ```bash
 pnpm run up
@@ -77,44 +77,44 @@ pnpm run up
 - DB config export to `.env`
 - API + Dashboard dev startup
 
-## 初回チェックリスト
+## First-Time Checklist
 
-1. GitHub CLI を認証（default auth mode）:
+1. Authenticate GitHub CLI (default auth mode):
 
    ```bash
    gh auth login
    ```
 
-2. Claude Code executor を使う場合は host 側で認証:
+2. If using Claude Code executor, authenticate on the host:
 
    ```bash
    claude /login
    ```
 
-3. Dashboard を開く:
+3. Open the Dashboard:
    - Dashboard: `http://localhost:5190`
    - API: `http://localhost:4301`
-4. Start ページで requirement を入力して実行
+4. Enter requirement on the Start page and run
    - default canonical requirement path: `docs/requirement.md`
-5. 進行状況を監視:
+5. Monitor progress:
    - `tasks`
    - `runs`
    - `judgements`
    - `logs`
-6. 状態が停滞した場合:
-   - `docs/state-model.md` の一次診断から着手
-   - `docs/operations.md` の runbook で詳細確認
+6. If state becomes stalled:
+   - Start with initial diagnosis in `docs/state-model.md`
+   - Check detailed runbook in `docs/operations.md`
 
-### 共通逆引き導線（状態語彙 -> 遷移 -> 担当 -> 実装）
+### Common Lookup Guide (state vocabulary -> transition -> owner -> implementation)
 
-- API で異常を見つけた場合:
-  - `docs/api-reference.md` の「2.2 API 起点の逆引き（状態語彙 -> 遷移 -> 担当 -> 実装）」
-- 状態語彙から遷移を追う場合:
+- If issues found via API:
+  - `docs/api-reference.md` "2.2 API-based lookup (state vocabulary -> transition -> owner -> implementation)"
+- To trace transitions from state vocabulary:
   - `docs/state-model.md` -> `docs/flow.md`
-- 担当 agent と実装ファイルまで追う場合:
-  - `docs/agent/README.md` の「実装追跡の最短ルート」
+- To trace to owning agent and implementation files:
+  - `docs/agent/README.md` "Shortest route for implementation tracing"
 
-## 起動と実行時挙動
+## Startup and Runtime Behavior
 
 - Planner is started only when backlog gates are clear.
 - Existing local/Issue/PR backlog is always prioritized.
@@ -125,14 +125,14 @@ pnpm run up
 
 Details: `docs/startup-patterns.md`, `docs/flow.md`
 
-## ドキュメントマップ
+## Documentation Map
 
-まずは用途別索引から確認してください:
+First check the index by use case:
 
 - `docs/README.md`
-  - reader lane（初見/運用/実装追従）を含みます
+  - includes reader lanes (first-time/operations/implementation tracing)
 
-導入時の推奨順:
+Recommended order for onboarding:
 
 - `docs/getting-started.md`
 - `docs/architecture.md`
@@ -141,7 +141,7 @@ Details: `docs/startup-patterns.md`, `docs/flow.md`
 - `docs/operations.md`
 - `docs/api-reference.md` の「2.2 API 起点の逆引き（状態語彙 -> 遷移 -> 担当 -> 実装）」
 
-実行時挙動の参照:
+Runtime behavior reference:
 
 - `docs/state-model.md`
 - `docs/flow.md`
@@ -151,7 +151,7 @@ Details: `docs/startup-patterns.md`, `docs/flow.md`
 - `docs/policy-recovery.md`
 - `docs/verification.md`
 
-agent 仕様の参照:
+Agent specification reference:
 
 - `docs/agent/README.md` (role comparison)
 - `docs/agent/planner.md`
@@ -162,21 +162,21 @@ agent 仕様の参照:
 - `docs/agent/docser.md`
 - `docs/agent/cycle-manager.md`
 
-設計方針:
+Design principles:
 
 - `docs/nonhumanoriented.md`
 
-## 認証とアクセス制御の注意
+## Authentication and Access Control Notes
 
 - API authentication middleware supports:
   - `X-API-Key` (`API_KEYS`)
   - `Authorization: Bearer <token>` (`API_SECRET` or custom validator)
-- `/health` と GitHub webhook endpoint（`/webhook/github`、prefix 構成時は `/api/webhook/github`）は auth-skipped.
+- `/health` and GitHub webhook endpoint (`/webhook/github`, `/api/webhook/github` when using API prefix) are auth-skipped.
 - System-control (`/system/*`, `POST /logs/clear`) access is checked by `canControlSystem()`:
   - `api-key` / `bearer`: always allowed
   - local insecure fallback: allowed unless `OPENTIGER_ALLOW_INSECURE_SYSTEM_CONTROL=false`
 
-## OSS としてのスコープ
+## OSS Scope
 
 openTiger is optimized for long-running autonomous repository workflows with explicit recovery paths.  
 It does **not** guarantee one-shot success under all external conditions, but it is designed to avoid silent stalls and continuously converge by switching recovery strategy.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,37 +1,37 @@
-# ドキュメント索引（openTiger）
+# Documentation Index (openTiger)
 
-このディレクトリは、openTiger の実装仕様を「導線」と「参照」に分けて整理しています。  
-ソースコードを真として、運用に必要な情報を段階的に読める構成です。
+This directory organizes openTiger implementation specifications into "navigation paths" and "references."  
+With source code as the source of truth, information necessary for operations is structured for progressive reading.
 
-## 0. 目的別ナビゲーション
+## 0. Purpose-Based Navigation
 
-| 目的 | 最短で読むページ |
+| Purpose | Shortest Page to Read |
 | --- | --- |
-| まず動かしたい | `docs/getting-started.md` |
-| 全体像を掴みたい | `docs/architecture.md` |
-| 設定キーを調整したい | `docs/config.md` |
-| API 連携したい | `docs/api-reference.md` |
-| 障害対応したい | `docs/operations.md` + `docs/flow.md` |
-| 状態停滞を最短で一次診断したい | `docs/state-model.md` |
-| `retry.reason` の意味を即確認したい | `docs/state-model.md` |
-| 状態語彙 -> 遷移 -> 担当 -> 実装で追いたい | `docs/state-model.md` -> `docs/flow.md` -> `docs/agent/README.md` |
-| 起動判定の式を確認したい | `docs/startup-patterns.md` |
-| agent の役割差分を確認したい | `docs/agent/README.md` |
+| Want to get it running first | `docs/getting-started.md` |
+| Want to grasp the overview | `docs/architecture.md` |
+| Want to tune config keys | `docs/config.md` |
+| Want API integration | `docs/api-reference.md` |
+| Need incident response | `docs/operations.md` + `docs/flow.md` |
+| Quick initial diagnosis of stalled state | `docs/state-model.md` |
+| Immediate lookup of `retry.reason` meanings | `docs/state-model.md` |
+| Trace by state vocabulary -> transition -> owner -> implementation | `docs/state-model.md` -> `docs/flow.md` -> `docs/agent/README.md` |
+| Confirm startup condition formulas | `docs/startup-patterns.md` |
+| Compare agent role differences | `docs/agent/README.md` |
 
-## 0.1 読者タイプ別の推奨レーン
+## 0.1 Recommended Lanes by Reader Type
 
-### レーンA: 初見ユーザー（最短で動かす）
+### Lane A: First-Time Users (shortest path to run)
 
 1. `docs/getting-started.md`
 2. `docs/architecture.md`
 3. `docs/operations.md`
 
-目的:
+Goals:
 
-- 最初の実行を通す
-- 起動後5分チェックまで完了する
+- Complete the first run
+- Finish the 5-minute post-startup check
 
-### レーンB: 運用担当（安定運用と復旧）
+### Lane B: Operations (stable operation and recovery)
 
 1. `docs/operations.md`
 2. `docs/config.md`
@@ -39,16 +39,16 @@
 4. `docs/flow.md`
 5. `docs/startup-patterns.md`
 
-目的:
+Goals:
 
-- 障害時の切り分けと再起動判断を短時間で行う
-- 設定変更の影響範囲を誤らない
+- Perform rapid triage and restart decisions during incidents
+- Avoid mistakes in impact scope of config changes
 
-状態停滞時のショートカット:
+Shortcut for stalled state:
 
-- `docs/state-model.md` -> `docs/flow.md` -> `docs/operations.md`（8.1「状態語彙 -> 遷移 -> 担当 -> 実装 の逆引き」）-> `docs/agent/README.md`
+- `docs/state-model.md` -> `docs/flow.md` -> `docs/operations.md` (8.1 "State vocabulary -> transition -> owner -> implementation lookup") -> `docs/agent/README.md`
 
-### レーンC: 実装追従（ソース差分を追う）
+### Lane C: Implementation Tracing (track source diffs)
 
 1. `docs/architecture.md`
 2. `docs/agent/README.md`
@@ -56,45 +56,45 @@
 4. `docs/api-reference.md`
 5. `docs/config.md`
 
-目的:
+Goals:
 
-- コンポーネント責務と実装境界を把握する
-- API/設定変更時に関連箇所を漏れなく追う
-- `docs/agent/*.md` の「実装参照（source of truth）」からコードへ最短で到達する
+- Understand component responsibilities and implementation boundaries
+- Trace related areas without omission when changing API/config
+- Reach code quickly via "Implementation reference (source of truth)" in `docs/agent/*.md`
 
-## 1. 初見ユーザー向け（最短導線）
+## 1. First-Time User Path (Shortest)
 
 1. `docs/getting-started.md`
-   - 導入、初回起動、Start ページでの実行開始まで
+   - Setup, first run, execution start via Start page
 2. `docs/architecture.md`
-   - コンポーネント責務とデータフロー
+   - Component responsibilities and data flow
 3. `docs/config.md`
-   - `system_config` と環境変数の設定参照
+   - `system_config` and environment variable reference
 4. `docs/api-reference.md`
-   - Dashboard/API 連携時の主要エンドポイント参照
+   - Main endpoints for Dashboard/API integration
 5. `docs/operations.md`
-   - 運用、障害復旧、ログ確認、runtime hatch
+   - Operations, incident recovery, log inspection, runtime hatch
 
-## 2. 実行モデル・復旧戦略
+## 2. Execution Model and Recovery Strategy
 
 - `docs/state-model.md`
-  - task/run/agent/cycle の状態定義
+  - State definitions for task/run/agent/cycle
 - `docs/flow.md`
-  - エンドツーエンドの状態遷移と回復ループ
+  - End-to-end state transitions and recovery loops
 - `docs/startup-patterns.md`
-  - 起動時 preflight 判定と runtime 収束条件
+  - Startup preflight rules and runtime convergence conditions
 - `docs/mode.md`
-  - `REPO_MODE` / `JUDGE_MODE` / 実行モードの運用指針
+  - `REPO_MODE` / `JUDGE_MODE` / execution mode operation guidelines
 - `docs/execution-mode.md`
-  - host/sandbox 実行差分と sandbox 認証
+  - host/sandbox execution differences and sandbox authentication
 - `docs/policy-recovery.md`
-  - policy violation 回復、allowedPaths 自己成長
+  - Policy violation recovery, allowedPaths self-growth
 - `docs/verification.md`
-  - Planner/Worker の検証コマンド解決戦略
+  - Planner/Worker verification command resolution strategy
 
-## 3. Agent 仕様
+## 3. Agent Specifications
 
-- `docs/agent/README.md`（横断比較）
+- `docs/agent/README.md` (cross-agent comparison)
 - `docs/agent/planner.md`
 - `docs/agent/dispatcher.md`
 - `docs/agent/worker.md`
@@ -103,16 +103,16 @@
 - `docs/agent/docser.md`
 - `docs/agent/cycle-manager.md`
 
-## 4. 設計思想・補助資料
+## 4. Design Principles and Supplementary Materials
 
 - `docs/nonhumanoriented.md`
-  - non-stalling を前提とした設計原則
+  - Design principles based on non-stalling assumption
 - `docs/requirement.md`
-  - requirement テンプレート例
+  - Requirement template example
 - `docs/idea.md`
-  - 改善アイデアメモ（将来計画）
+  - Improvement idea notes (future plans)
 
-## 推奨読了順（最短）
+## Recommended Reading Order (Shortest)
 
 1. `docs/getting-started.md`
 2. `docs/architecture.md`
@@ -122,15 +122,15 @@
 6. `docs/flow.md`
 7. `docs/agent/README.md`
 
-## 変更時の逆引き
+## Lookup When Making Changes
 
-- 起動条件・replan 条件を変更した場合:
+- When changing startup conditions or replan conditions:
   - `docs/startup-patterns.md`
-  - `docs/flow.md`（関連する runtime 影響）
-- task 状態遷移や blocked 回復を変更した場合:
+  - `docs/flow.md` (related runtime impact)
+- When changing task state transitions or blocked recovery:
   - `docs/state-model.md`
   - `docs/flow.md`
   - `docs/operations.md`
-- agent 実装責務を変更した場合:
+- When changing agent implementation responsibilities:
   - `docs/agent/README.md`
-  - 対象の `docs/agent/*.md`
+  - Target `docs/agent/*.md`

--- a/docs/agent/cycle-manager.md
+++ b/docs/agent/cycle-manager.md
@@ -1,62 +1,62 @@
-# サイクルマネージャー（Cycle Manager）Agent 仕様
+# Cycle Manager Agent Specification
 
-関連:
+Related:
 
 - `docs/agent/README.md`
 - `docs/flow.md`
 - `docs/operations.md`
 
-## 1. 役割
+## 1. Role
 
-Cycle Manager は長時間運用を前提に、システム全体の収束を維持します。  
-監視・クリーンアップ・再計画（replan）を周期実行し、停止しにくい運用を支えます。
+Cycle Manager maintains system-wide convergence for long-running operation.  
+It runs monitoring, cleanup, and replanning periodically to support non-stalling operation.
 
-責務外:
+Out of scope:
 
-- 個別 task の実装内容を直接変更すること
-- PR 差分の承認/差し戻し判定
+- Directly modifying individual task implementation content
+- PR diff approve/rework decisions
 
-## 2. ランタイムループ
+## 2. Runtime Loops
 
-- 監視ループ（monitor loop）
-  - cycle 終了条件判定
-  - anomaly 検知
-  - cost 上限監視
-  - backlog 枯渇時の issue preflight / replan 判定
-- クリーンアップループ（cleanup loop）
-  - expired lease / offline agent / stuck run の回復
-  - failed / blocked task の cooldown 後 requeue
-- 統計更新ループ（stats loop）
-  - cycle stats と system state の更新
+- Monitor loop
+  - Cycle end condition evaluation
+  - Anomaly detection
+  - Cost limit monitoring
+  - Issue preflight / replan decision when backlog is depleted
+- Cleanup loop
+  - Recovery of expired lease / offline agent / stuck run
+  - Requeue of failed/blocked tasks after cooldown
+- Stats loop
+  - Cycle stats and system state updates
 
-## 3. サイクルライフサイクル
+## 3. Cycle Lifecycle
 
-- 起動時に既存 `running` cycle を復元（なければ auto-start）
-- 終了条件:
-  - 経過時間上限
-  - 完了タスク数上限
-  - failure rate 上限
-- cycle 終了時は必要に応じて cleanup の後に次 cycle を開始
+- Restore existing `running` cycle on startup (or auto-start if none)
+- End conditions:
+  - Maximum elapsed time
+  - Maximum completed task count
+  - Maximum failure rate
+- On cycle end, start next cycle after cleanup when needed
 
-## 4. 異常検知と回復
+## 4. Anomaly Detection and Recovery
 
-- 監視対象:
-  - 高失敗率（high failure rate）
-  - コスト急増（cost spike）
-  - 停滞 task（stuck task）
-  - 進捗停止（no progress）
-  - agent タイムアウト（agent timeout）
-- `stuck_task` など一部 critical anomaly では cycle restart を実施
-- anomaly は重複通知 cooldown を持つ
+- Monitored:
+  - High failure rate
+  - Cost spike
+  - Stuck task
+  - No progress
+  - Agent timeout
+- For some critical anomalies like `stuck_task`, cycle restart is performed
+- Anomalies have duplicate notification cooldown
 
-## 5. 再計画（replan）と backlog 方針
+## 5. Replan and Backlog Policy
 
-- task backlog が空になった後、まず `/system/preflight` で issue backlog を同期
-- issue backlog がある間は replan を延期
-- backlog が空で、かつ planner idle など条件を満たす場合のみ replan
-- requirement hash + repo head を署名化し、設定により no-diff replan を抑止
+- After task backlog is empty, first sync issue backlog via `/system/preflight`
+- Replan is deferred while issue backlog exists
+- Replan only when backlog is empty and conditions such as planner idle are met
+- Requirement hash + repo head are signed to suppress no-diff replan per config
 
-## 6. 操作コマンド（CLI）
+## 6. CLI Commands
 
 - `status`
 - `anomalies`
@@ -65,15 +65,15 @@ Cycle Manager は長時間運用を前提に、システム全体の収束を維
 - `new-cycle`
 - `cleanup`
 
-## 7. 実装参照（source of truth）
+## 7. Implementation Reference (Source of Truth)
 
-- 起動と共通制御: `apps/cycle-manager/src/main.ts`, `apps/cycle-manager/src/cycle-controller.ts`
-- メインループ: `apps/cycle-manager/src/main/loops.ts`
-- backlog 同期と再計画: `apps/cycle-manager/src/main/backlog-preflight.ts`, `apps/cycle-manager/src/main/replan.ts`
-- 異常検知: `apps/cycle-manager/src/monitors/anomaly-detector.ts`
-- 回復クリーンアップ: `apps/cycle-manager/src/cleaners/cleanup.ts`, `apps/cycle-manager/src/cleaners/cleanup-retry.ts`
+- Startup and common control: `apps/cycle-manager/src/main.ts`, `apps/cycle-manager/src/cycle-controller.ts`
+- Main loop: `apps/cycle-manager/src/main/loops.ts`
+- Backlog sync and replan: `apps/cycle-manager/src/main/backlog-preflight.ts`, `apps/cycle-manager/src/main/replan.ts`
+- Anomaly detection: `apps/cycle-manager/src/monitors/anomaly-detector.ts`
+- Recovery cleanup: `apps/cycle-manager/src/cleaners/cleanup.ts`, `apps/cycle-manager/src/cleaners/cleanup-retry.ts`
 
-## 8. 主な設定
+## 8. Main Configuration
 
 - `MONITOR_INTERVAL_MS`
 - `CLEANUP_INTERVAL_MS`

--- a/docs/agent/docser.md
+++ b/docs/agent/docser.md
@@ -1,50 +1,50 @@
-# ドキュメント担当（Docser）Agent 仕様
+# Docser Agent Specification
 
-関連:
+Related:
 
 - `docs/agent/README.md`
 - `docs/agent/worker.md`
 - `docs/verification.md`
 - `docs/policy-recovery.md`
 
-## 1. 役割
+## 1. Role
 
-Docser は `AGENT_ROLE=docser` で動作する Worker ランタイムの派生ロールです。  
-このページは Docser 固有の差分のみを記載します。
+Docser is a derived role of the Worker runtime running with `AGENT_ROLE=docser`.  
+This page documents only Docser-specific differences.
 
-共通の実行フロー・状態遷移・安全制約は `docs/agent/worker.md` を参照してください。
+For shared execution flow, state transitions, and safety constraints, see `docs/agent/worker.md`.
 
-## 2. 主な起点
+## 2. Main Triggers
 
-- Judge 後のドキュメント追従 task 作成
-- repository の docs が不足・未整備な場合の Planner による doc-gap task 注入
+- Doc-follow task creation after Judge
+- Planner-injected doc-gap task when repository docs are insufficient or incomplete
 
-## 3. 期待される出力
+## 3. Expected Output
 
-- allowed paths 配下に限定した簡潔なドキュメント差分
-- run/task レコードに紐づく検証済みドキュメント更新
+- Concise documentation diffs under allowed paths
+- Verified documentation updates tied to run/task records
 
-## 4. ガードレール
+## 4. Guardrails
 
-- 推測的な設計案より、実装済みの事実を優先する
-- strict な allowed paths を厳守する
-- 変更をレビュー可能なサイズに保ち、影響範囲を絞る
-- doc-safe な検証コマンド（例: `pnpm run check`）を使う
-- LLM ベースの policy recovery は行わず、deterministic な処理に限定する
+- Prefer implemented facts over speculative design
+- Strictly respect strict allowed paths
+- Keep changes reviewable in size and scope
+- Use doc-safe verification commands (e.g. `pnpm run check`)
+- No LLM-based policy recovery; limited to deterministic handling
 
-## 5. 主な設定
+## 5. Main Configuration
 
 - `AGENT_ROLE=docser`
 - `DOCSER_MODEL`
 - `DOCSER_INSTRUCTIONS_PATH`
 - `OPENTIGER_LOG_DIR`
 
-共通設定（retry/policy recovery/verify recovery など）は `docs/agent/worker.md` を参照してください。
+For shared settings (retry/policy recovery/verify recovery, etc.), see `docs/agent/worker.md`.
 
-## 6. 実装参照（source of truth）
+## 6. Implementation Reference (Source of Truth)
 
-- role 起動分岐: `apps/worker/src/main.ts`
-- role 固有指示: `apps/worker/instructions/docser.md`
-- doc-safe 検証制約: `apps/worker/src/worker-runner-verification.ts`
-- docser 固有補助挙動: `apps/worker/src/worker-task-helpers.ts`
-- 共通実行本体: `apps/worker/src/worker-runner.ts`
+- Role startup branching: `apps/worker/src/main.ts`
+- Role-specific instructions: `apps/worker/instructions/docser.md`
+- Doc-safe verification constraints: `apps/worker/src/worker-runner-verification.ts`
+- Docser-specific helper behavior: `apps/worker/src/worker-task-helpers.ts`
+- Shared execution body: `apps/worker/src/worker-runner.ts`

--- a/docs/agent/tester.md
+++ b/docs/agent/tester.md
@@ -1,37 +1,37 @@
-# テスター（Tester）Agent 仕様
+# Tester Agent Specification
 
-関連:
+Related:
 
 - `docs/agent/README.md`
 - `docs/agent/worker.md`
 - `docs/verification.md`
 
-## 1. 役割
+## 1. Role
 
-Tester は `AGENT_ROLE=tester` で動作する Worker ランタイムの派生ロールです。  
-このページは Tester 固有の差分のみを記載します。
+Tester is a derived role of the Worker runtime running with `AGENT_ROLE=tester`.  
+This page documents only Tester-specific differences.
 
-共通の実行フロー・状態遷移・安全制約は `docs/agent/worker.md` を参照してください。
+For shared execution flow, state transitions, and safety constraints, see `docs/agent/worker.md`.
 
-## 2. 主な責務
+## 2. Main Responsibilities
 
-- unit/integration/e2e テストの追加・修正
-- 不安定な検証コマンドの安定化
-- Judge や autofix ループで再現可能な失敗文脈の提供
+- Add/update unit/integration/e2e tests
+- Stabilize flaky verification commands
+- Provide reproducible failure context for Judge and autofix loops
 
-## 3. 配布前連携（Planner/Dispatcher）
+## 3. Pre-Dispatch Coordination (Planner/Dispatcher)
 
-- Planner が task 内容やパスのヒントから tester ロールを推定
-- Dispatcher がロール付き task を idle な tester へ割り当て
+- Planner infers tester role from task content and path hints
+- Dispatcher assigns role-tagged tasks to idle testers
 
-## 4. 検証方針
+## 4. Verification Policy
 
-- 非対話コマンドのみ許可
-- watch モードコマンドは避ける
-- Planner/Worker の verify contract を利用可能
-- e2e コマンドは「明示的に e2e 要求がある task」にのみ自動補完される
+- Only non-interactive commands allowed
+- Avoid watch-mode commands
+- Can use Planner/Worker verify contract
+- e2e commands are auto-added only for tasks that explicitly request e2e
 
-## 5. 主な設定
+## 5. Main Configuration
 
 - `AGENT_ROLE=tester`
 - `TESTER_MODEL`
@@ -39,11 +39,11 @@ Tester は `AGENT_ROLE=tester` で動作する Worker ランタイムの派生�
 - `WORKER_AUTO_VERIFY_MODE`
 - `WORKER_VERIFY_CONTRACT_PATH`
 
-共通設定（retry/policy recovery/verify recovery など）は `docs/agent/worker.md` を参照してください。
+For shared settings (retry/policy recovery/verify recovery, etc.), see `docs/agent/worker.md`.
 
-## 6. 実装参照（source of truth）
+## 6. Implementation Reference (Source of Truth)
 
-- role 起動分岐: `apps/worker/src/main.ts`
-- role 固有指示: `apps/worker/instructions/tester.md`
-- 検証コマンド自動補完: `apps/worker/src/steps/verify/repo-scripts.ts`
-- 共通実行本体: `apps/worker/src/worker-runner.ts`, `apps/worker/src/worker-runner-verification.ts`
+- Role startup branching: `apps/worker/src/main.ts`
+- Role-specific instructions: `apps/worker/instructions/tester.md`
+- Verification command auto-completion: `apps/worker/src/steps/verify/repo-scripts.ts`
+- Shared execution body: `apps/worker/src/worker-runner.ts`, `apps/worker/src/worker-runner-verification.ts`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,9 +1,9 @@
-# インターフェース参照（API）
+# API Reference
 
-openTiger API は Hono ベースで、ダッシュボードからも同じエンドポイントを利用します。  
-ベース URL は通常 `http://localhost:4301` です。
+The openTiger API is Hono-based; the dashboard uses the same endpoints.  
+Base URL is typically `http://localhost:4301`.
 
-関連:
+Related:
 
 - `docs/config.md`
 - `docs/operations.md`
@@ -11,105 +11,104 @@ openTiger API は Hono ベースで、ダッシュボードからも同じエン
 - `docs/agent/dispatcher.md`
 - `docs/agent/cycle-manager.md`
 
-## 1. 認証とレート制限
+## 1. Authentication and Rate Limiting
 
-### 認証方式
+### Authentication Methods
 
 - `X-API-Key` (`API_KEYS`)
-- `Authorization: Bearer <token>`（`API_SECRET` または独自バリデーター）
+- `Authorization: Bearer <token>` (`API_SECRET` or custom validator)
 
-認証スキップ:
+Auth skipped:
 
 - `/health*`
 - `/webhook/github`
-- `/api/webhook/github`（API プレフィックス配下で公開する構成向け互換パス）
+- `/api/webhook/github` (compatibility path when API prefix is used)
 
-system 制御系 API は `canControlSystem()` で許可判定されます。
+System control APIs require `canControlSystem()` for access.
 
-- `api-key` / `bearer` は常に許可
-- ローカル運用時は `OPENTIGER_ALLOW_INSECURE_SYSTEM_CONTROL !== "false"` で許可される設計
+- `api-key` / `bearer`: always allowed
+- Local operation: allowed unless `OPENTIGER_ALLOW_INSECURE_SYSTEM_CONTROL=false`
 
-主な対象:
+Main targets:
 
 - `/system/*`
 - `POST /logs/clear`
 
-### レート制限
+### Rate Limiting
 
-- 既定: 1分あたり 100 リクエスト
-- Redis 利用可能時は Redis カウンタ、失敗時は in-memory にフォールバック
+- Default: 100 requests per minute
+- Redis counter when available; in-memory fallback on failure
 
 ---
 
-## 2. 運用目的別 API マップ
+## 2. API Map by Operation Purpose
 
-| 運用目的 | 主な API |
+| Purpose | Main APIs |
 | --- | --- |
-| ヘルス確認 | `GET /health`, `GET /health/ready` |
-| 状態監視 | `GET /tasks`, `GET /runs`, `GET /judgements`, `GET /agents`, `GET /logs/all` |
-| 設定変更 | `GET /config`, `PATCH /config` |
-| 起動制御 | `POST /system/processes/:name/start`, `POST /system/processes/:name/stop`, `POST /system/processes/stop-all` |
-| 起動前判定 | `POST /system/preflight` |
-| 復旧・メンテナンス | `POST /system/cleanup`, `POST /logs/clear` |
-| GitHub 連携 | `GET /system/github/auth`, `GET /system/github/repos`, `POST /system/github/repo`, `POST /webhook/github` |
-| requirement 更新 | `GET /system/requirements`, `POST /system/requirements` |
+| Health check | `GET /health`, `GET /health/ready` |
+| State monitoring | `GET /tasks`, `GET /runs`, `GET /judgements`, `GET /agents`, `GET /logs/all` |
+| Config changes | `GET /config`, `PATCH /config` |
+| Startup control | `POST /system/processes/:name/start`, `POST /system/processes/:name/stop`, `POST /system/processes/stop-all` |
+| Pre-start validation | `POST /system/preflight` |
+| Recovery/maintenance | `POST /system/cleanup`, `POST /logs/clear` |
+| GitHub integration | `GET /system/github/auth`, `GET /system/github/repos`, `POST /system/github/repo`, `POST /webhook/github` |
+| Requirement updates | `GET /system/requirements`, `POST /system/requirements` |
 
-補足:
+Note:
 
-- task/run の状態語彙（`queued`, `blocked`, `awaiting_judge` など）は `docs/state-model.md` を参照してください。
+- For task/run state vocabulary (`queued`, `blocked`, `awaiting_judge`, etc.), see `docs/state-model.md`.
 
-## 2.1 運用担当向け最小 API セット
+## 2.1 Minimal API Set for Operations
 
-障害切り分けや日次運用で、まず押さえる最小セットです。
+Minimum set for incident triage and daily operations.
 
-| 用途 | API | 見るポイント |
+| Use | API | What to check |
 | --- | --- | --- |
-| 全体ヘルス | `GET /health/ready` | DB/Redis の疎通可否 |
-| process 状態 | `GET /system/processes` | `running/stopped` の偏り、必要 process の欠落 |
-| agent 稼働 | `GET /agents` | `offline` の偏り、ロールごとの稼働数 |
-| task 滞留 | `GET /tasks` | `queued` 固着、`blocked` の急増 |
-| run 異常 | `GET /runs` | 同一エラーの連続 `failed`、`running` 長期化 |
-| judge 停滞 | `GET /judgements` | non-approve の連鎖、未処理 backlog |
-| 相関ログ | `GET /logs/all` | dispatcher/worker/judge/cycle-manager の時系列 |
+| Overall health | `GET /health/ready` | DB/Redis connectivity |
+| Process state | `GET /system/processes` | running/stopped distribution, missing processes |
+| Agent activity | `GET /agents` | offline distribution, counts per role |
+| Task backlog | `GET /tasks` | stuck `queued`, surge in `blocked` |
+| Run anomalies | `GET /runs` | consecutive `failed` with same error, long `running` |
+| Judge stall | `GET /judgements` | non-approve chain, unprocessed backlog |
+| Correlated logs | `GET /logs/all` | dispatcher/worker/judge/cycle-manager timeline |
 
-運用時の確認順（シーケンス）は `docs/operations.md` の  
-「変更後の確認チェックリスト」を一次参照にしてください。
+For operation check sequence, refer to "Post-change verification checklist" in `docs/operations.md`.
 
-## 2.2 API 起点の逆引き（状態語彙 -> 遷移 -> 担当 -> 実装）
+## 2.2 API-Based Lookup (State Vocabulary -> Transition -> Owner -> Implementation)
 
-API で異常を見つけたあとに、状態語彙 -> 遷移 -> 担当 -> 実装の順で追う共通導線です。
+Common path when tracing from state vocabulary to transition to owner to implementation after finding anomalies via API.
 
-| 起点（API/症状） | 状態語彙の確認先 | 遷移の確認先（flow） | 担当 agent の確認先 | 実装の確認先 |
+| Starting point (API/symptom) | State vocabulary ref | Transition ref (flow) | Owner agent ref | Implementation ref |
 | --- | --- | --- | --- | --- |
-| `GET /tasks` で `queued`/`running` が停滞 | `docs/state-model.md` 7章 | `docs/flow.md` 2章, 5章, 6章 | Dispatcher/Worker（`docs/agent/dispatcher.md`, `docs/agent/worker.md`） | `apps/dispatcher/src/`, `apps/worker/src/` |
-| `GET /tasks` で `awaiting_judge` が停滞 | `docs/state-model.md` 2章, 7章 | `docs/flow.md` 3章, 4章, 7章 | Judge（`docs/agent/judge.md`） | `apps/judge/src/` |
-| `GET /tasks` で `quota_wait`/`needs_rework` が連鎖 | `docs/state-model.md` 2.2章, 7章 | `docs/flow.md` 3章, 6章, 8章 | Worker/Judge/Cycle Manager（各 agent 仕様） | 各 agent 仕様末尾の「実装参照（source of truth）」節 |
-| `GET /tasks` で `issue_linking` が停滞 | `docs/state-model.md` 2章, 7章 | `docs/flow.md` 3章 | Planner（`docs/agent/planner.md`） | `apps/planner/src/` |
+| `queued`/`running` stuck in `GET /tasks` | `docs/state-model.md` 7 | `docs/flow.md` 2, 5, 6 | Dispatcher/Worker (`docs/agent/dispatcher.md`, `docs/agent/worker.md`) | `apps/dispatcher/src/`, `apps/worker/src/` |
+| `awaiting_judge` stuck in `GET /tasks` | `docs/state-model.md` 2, 7 | `docs/flow.md` 3, 4, 7 | Judge (`docs/agent/judge.md`) | `apps/judge/src/` |
+| `quota_wait`/`needs_rework` chain in `GET /tasks` | `docs/state-model.md` 2.2, 7 | `docs/flow.md` 3, 6, 8 | Worker/Judge/Cycle Manager (each agent spec) | "Implementation reference" in each agent spec |
+| `issue_linking` stuck in `GET /tasks` | `docs/state-model.md` 2, 7 | `docs/flow.md` 3 | Planner (`docs/agent/planner.md`) | `apps/planner/src/` |
 
-補足:
+Note:
 
-- 運用ショートカット表は `docs/operations.md` の「8.1 状態語彙 -> 遷移 -> 担当 -> 実装 の逆引き」を参照してください。
-- 担当 agent と実装入口は `docs/agent/README.md` の「実装追跡の最短ルート」を参照してください。
+- Operation shortcut table: `docs/operations.md` "8.1 State vocabulary -> transition -> owner -> implementation lookup"
+- Owner agent and implementation entry: `docs/agent/README.md` "Shortest route for implementation tracing"
 
 ---
 
-## 3. 主要エンドポイント一覧
+## 3. Main Endpoints
 
-### ヘルスチェック（Health）
+### Health
 
 - `GET /health`
 - `GET /health/ready`
-  - DB と Redis の疎通確認を返します
+  - Returns DB and Redis connectivity check
 
-### 設定（Config）
+### Config
 
 - `GET /config`
-  - `system_config` の現在値を返す
+  - Returns current `system_config` values
 - `PATCH /config`
   - `{ updates: Record<string, string> }`
-  - 未知キーは拒否
+  - Unknown keys are rejected
 
-### タスク（Tasks）
+### Tasks
 
 - `GET /tasks`
 - `GET /tasks/:id`
@@ -117,14 +116,14 @@ API で異常を見つけたあとに、状態語彙 -> 遷移 -> 担当 -> 実�
 - `PATCH /tasks/:id`
 - `DELETE /tasks/:id`
 
-補足:
+Note:
 
-- failed/blocked タスクには `retry` 情報が付与されます（cooldown / reason / retryCount など）
-- `retry.reason` の主な値:
+- failed/blocked tasks include `retry` info (cooldown / reason / retryCount, etc.)
+- Main `retry.reason` values:
   - `cooldown_pending`, `retry_due`, `awaiting_judge`, `quota_wait`, `needs_rework`
-- 詳細な語彙（`retry_exhausted`, `non_retryable_failure`, `unknown`, `failureCategory`）は `docs/state-model.md` を参照してください。
+- Full vocabulary (`retry_exhausted`, `non_retryable_failure`, `unknown`, `failureCategory`) in `docs/state-model.md`
 
-`retry` 例:
+`retry` example:
 
 ```json
 {
@@ -138,7 +137,7 @@ API で異常を見つけたあとに、状態語彙 -> 遷移 -> 担当 -> 実�
 }
 ```
 
-### 実行履歴（Runs）
+### Runs
 
 - `GET /runs`
 - `GET /runs/:id`
@@ -148,7 +147,7 @@ API で異常を見つけたあとに、状態語彙 -> 遷移 -> 担当 -> 実�
 - `POST /runs/:id/cancel`
 - `POST /runs/:id/artifacts`
 
-### エージェント（Agents）
+### Agents
 
 - `GET /agents`
 - `GET /agents/:id`
@@ -156,62 +155,62 @@ API で異常を見つけたあとに、状態語彙 -> 遷移 -> 担当 -> 実�
 - `POST /agents/:id/heartbeat`
 - `DELETE /agents/:id`
 
-補足:
+Note:
 
-- `GET /agents` は `planner/worker/tester/docser/judge` の稼働状態を返します。
-- Dispatcher / Cycle Manager は process として管理されるため、`GET /system/processes` で確認してください。
+- `GET /agents` returns `planner/worker/tester/docser/judge` status.
+- Dispatcher / Cycle Manager are managed as processes; use `GET /system/processes`.
 
-### プラン（Plans）
+### Plans
 
 - `GET /plans`
-  - `planner.plan_created` イベントから plan スナップショットを返す
+  - Returns plan snapshots from `planner.plan_created` events
 
-### 判定（Judgements）
+### Judgements
 
 - `GET /judgements`
 - `GET /judgements/:id/diff`
 
-### ログ（Logs）
+### Logs
 
 - `GET /logs/agents/:id`
 - `GET /logs/cycle-manager`
 - `GET /logs/all`
 - `POST /logs/clear`
 
-### 連携通知（Webhook / GitHub）
+### Webhook / GitHub
 
 - `POST /webhook/github`
-  - `GITHUB_WEBHOOK_SECRET` があれば署名検証を行う
+  - Signature verification when `GITHUB_WEBHOOK_SECRET` is set
 
-実装上の現在挙動:
+Current implementation behavior:
 
-- 受信イベントは `events` テーブルへ記録
-- `issues` / `pull_request` / `push` / `check_run` / `check_suite` を処理
-- PR が close+merge されたとき、PR 本文に `[task:<uuid>]` が含まれる場合は該当 task を `done` 更新
-- それ以外は主に記録/通知用途で、planner/dispatcher の主駆動は `/system/preflight` 系にあります
+- Received events stored in `events` table
+- Handles `issues` / `pull_request` / `push` / `check_run` / `check_suite`
+- When PR is closed+merged with `[task:<uuid>]` in body, updates task to `done`
+- Otherwise mainly for recording/notification; planner/dispatcher drive via `/system/preflight` etc.
 
 ---
 
-## 4. システム API
+## 4. System APIs
 
-### 認証状態チェック
+### Auth Status
 
 - `GET /system/github/auth`
 - `GET /system/claude/auth?environment=host|sandbox`
 
-### 要件操作（requirement）
+### Requirement Operations
 
 - `GET /system/requirements`
 - `POST /system/requirements`
-  - 正式保存先 `docs/requirement.md` へ同期
-  - `git` repository の場合は snapshot commit/push を試行
+  - Syncs to canonical path `docs/requirement.md`
+  - For git repositories, attempts snapshot commit/push
 
-### 起動前判定（preflight）
+### Preflight
 
 - `POST /system/preflight`
-  - requirement 内容 + local backlog + GitHub issue/PR backlog から推奨起動構成を返す
+  - Returns recommended startup configuration from requirement content + local backlog + GitHub issue/PR backlog
 
-### プロセスマネージャー（system）
+### Process Manager (system)
 
 - `GET /system/processes`
 - `GET /system/processes/:name`
@@ -219,39 +218,39 @@ API で異常を見つけたあとに、状態語彙 -> 遷移 -> 担当 -> 実�
 - `POST /system/processes/:name/stop`
 - `POST /system/processes/stop-all`
 
-### リポジトリ操作（GitHub）
+### Repository Operations (GitHub)
 
 - `POST /system/github/repo`
-  - リポジトリ作成 + config 同期
+  - Create repository + config sync
 - `GET /system/github/repos`
-  - 認証ユーザーでアクセス可能な repo 一覧
+  - List repos accessible to authenticated user
 
-### ホスト情報（host）
+### Host Info
 
 - `GET /system/host/neofetch`
 - `GET /system/host/context`
 
-### メンテナンス
+### Maintenance
 
 - `POST /system/cleanup`
-  - runtime テーブルと queue を初期化
+  - Initializes runtime tables and queue
 
 ---
 
-## 5. preflight の重要挙動
+## 5. Important Preflight Behavior
 
-- Planner は次をすべて満たすときのみ推奨されます:
-  - requirement が空でない
-  - issue backlog なし
-  - judge backlog なし
-  - local task backlog なし
-- issue -> task 自動生成は「明示 role」が必須です
+- Planner is recommended only when all of the following hold:
+  - Requirement is non-empty
+  - No issue backlog
+  - No judge backlog
+  - No local task backlog
+- Issue -> task auto-generation requires explicit role:
   - label: `role:worker|role:tester|role:docser`
-  - または本文（body）に `Agent:` / `Role:` を記述
+  - or body with `Agent:` / `Role:` or `## Agent` section
 
-## 6. 代表レスポンス例
+## 6. Sample Responses
 
-### `POST /system/preflight`（抜粋）
+### `POST /system/preflight` (excerpt)
 
 ```json
 {
@@ -287,7 +286,7 @@ API で異常を見つけたあとに、状態語彙 -> 遷移 -> 担当 -> 実�
 }
 ```
 
-### `GET /system/processes`（抜粋）
+### `GET /system/processes` (excerpt)
 
 ```json
 {
@@ -312,14 +311,14 @@ API で異常を見つけたあとに、状態語彙 -> 遷移 -> 担当 -> 実�
 
 ---
 
-## 7. 実装連携時の注意
+## 7. Integration Notes
 
-- command 実行 API を外部から直接呼ぶ設計ではなく、process manager 経由で制御します
-- `stop-all` は running run を cancel/requeue し、agent 状態も更新します
-- sandbox 実行時、worker/tester/docser の host process は通常起動しません
-- `/system/*` と `POST /logs/clear` は `canControlSystem()` の許可条件で実行されます
+- No direct command execution API from outside; control via process manager
+- `stop-all` cancels/requeues running runs and updates agent state
+- In sandbox execution, worker/tester/docser host processes are not normally started
+- `/system/*` and `POST /logs/clear` require `canControlSystem()` permission
 
-運用トラブル時の補助資料:
+Supplemental material for operational issues:
 
-- dispatch/lease 問題: `docs/agent/dispatcher.md`
-- 収束/再計画問題: `docs/agent/cycle-manager.md`
+- dispatch/lease: `docs/agent/dispatcher.md`
+- convergence/replan: `docs/agent/cycle-manager.md`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,8 @@
-# はじめに
+# Getting Started
 
-このガイドは、openTiger を初回起動して最初の自律実行を開始するまでの最短手順です。
+This guide provides the shortest path from first run to starting autonomous execution.
 
-関連:
+Related:
 
 - `docs/architecture.md`
 - `docs/config.md`
@@ -10,123 +10,123 @@
 - `docs/operations.md`
 - `docs/agent/README.md`
 
-## 1. 前提
+## 1. Prerequisites
 
 - Node.js `>=20`
 - pnpm `9.x`
 - Docker
-- GitHub CLI (`gh`) 推奨
+- GitHub CLI (`gh`) recommended
 
-Claude Code 実行器を使う場合は `claude` CLI も必要です。
+Claude Code executor requires the `claude` CLI.
 
-## 2. セットアップ
+## 2. Setup
 
 ```bash
 pnpm run setup
 ```
 
-## 3. 認証（初回のみ）
+## 3. Authentication (First Time Only)
 
-### 連携設定（GitHub）
+### GitHub Integration
 
-デフォルトは `GITHUB_AUTH_MODE=gh` です。
+Default is `GITHUB_AUTH_MODE=gh`.
 
 ```bash
 gh auth login
 ```
 
-`token` モードを使う場合は、System Config で `GITHUB_TOKEN` を設定してください。
+For token mode, set `GITHUB_TOKEN` in System Config.
 
-### `LLM_EXECUTOR=claude_code` 利用時
+### When Using `LLM_EXECUTOR=claude_code`
 
 ```bash
 claude /login
 ```
 
-## 4. 起動
+## 4. Startup
 
 ```bash
 pnpm run up
 ```
 
-このコマンドは次を実行します。
+This command:
 
-- build
-- `postgres` / `redis` 起動
-- DB schema push
-- runtime hatch disarm
-- DB設定を `.env` へ export
-- API/Dashboard 起動
+- Builds
+- Starts `postgres` / `redis`
+- Pushes DB schema
+- Disarms runtime hatch
+- Exports DB config to `.env`
+- Starts API/Dashboard
 
-## 5. Dashboard にアクセス
+## 5. Access Dashboard
 
 - Dashboard: `http://localhost:5190`
 - API: `http://localhost:4301`
 
-## 6. Start ページで最初の実行を開始する
+## 6. Start First Execution on Start Page
 
-1. requirement を入力
-2. `EXECUTE RUN` を実行
-3. preflight 推奨に従って process を起動
+1. Enter requirement
+2. Run `EXECUTE RUN`
+3. Start processes per preflight recommendation
 
-重要:
+Important:
 
-- backlog（Issue/PR/ローカルタスク）がある場合、Planner は意図的にスキップされます。
-- Planner は backlog が空のときのみ開始されます。
+- With backlog (Issue/PR/local tasks), Planner is intentionally skipped
+- Planner starts only when backlog is empty
 
-## 7. 進行状況の確認
+## 7. Monitor Progress
 
-- `tasks`: タスク状態
-- `runs`: 実行結果・ログ
-- `judgements`: Judge 評価
-- `logs`: プロセスログ集約
+- `tasks`: task state
+- `runs`: execution results and logs
+- `judgements`: Judge evaluations
+- `logs`: aggregated process logs
 
-## 8. 初回起動後の最初の5分チェック
+## 8. First 5-Minute Check After Startup
 
-起動直後に次を確認すると、初期不整合を早く検知できます。
+These checks help detect initial misconfig quickly:
 
-1. process が生きている
-   - `GET /system/processes` で `dispatcher` / `cycle-manager` / `worker-*` / `judge-*` を確認
-2. agent が登録されている
-   - `GET /agents` で `idle`/`busy` の agent が見えることを確認
-3. task が遷移している
-   - `queued` のまま固定されず、`running` か `blocked/done` に進むことを確認
-4. run が連続失敗していない
-   - `GET /runs` で同一エラーの連続 `failed` がないことを確認
-5. ログに初期化エラーがない
-   - `GET /logs/all` で認証・接続・設定値エラーが出ていないことを確認
+1. Processes are running
+   - Confirm `dispatcher` / `cycle-manager` / `worker-*` / `judge-*` via `GET /system/processes`
+2. Agents are registered
+   - Confirm `idle`/`busy` agents via `GET /agents`
+3. Tasks are transitioning
+   - Confirm `queued` doesn't stay fixed; moves to `running` or `blocked`/`done`
+4. Runs are not failing repeatedly
+   - Confirm no consecutive `failed` with same error via `GET /runs`
+5. No startup errors in logs
+   - Confirm no auth/connection/config errors in `GET /logs/all`
 
-詳細な運用チェックは `docs/operations.md` を参照してください。
-状態遷移で詰まる場合は `docs/state-model.md` の一次診断テーブルから着手してください。
+For detailed operation checks, see `docs/operations.md`.  
+For state transitions that stall, start with the initial diagnosis table in `docs/state-model.md`.
 
-### 8.1 共通逆引き導線（状態語彙 -> 遷移 -> 担当 -> 実装、初見向け）
+### 8.1 Common Lookup Path (State Vocabulary -> Transition -> Owner -> Implementation, for First-Time Users)
 
-初見ユーザーは、次の順で確認すると切り分けしやすくなります。
+First-time users can triage by:
 
-1. 状態語彙を確認する  
-   - `docs/state-model.md`（7章）
-2. どこで詰まるかを遷移で確認する  
-   - `docs/flow.md`（該当する章）
-3. API の確認順を実行する  
-   - `docs/operations.md`（11章）
-4. 担当 agent と実装を特定する  
-   - `docs/agent/README.md`（FAQ と実装追跡ルート）
-5. API 起点で追う場合は逆引きを使う  
-   - `docs/api-reference.md`（2.2）
+1. Confirm state vocabulary  
+   - `docs/state-model.md` (7)
+2. Check where it stalls via transitions  
+   - `docs/flow.md` (relevant section)
+3. Run API check sequence  
+   - `docs/operations.md` (11)
+4. Identify owning agent and implementation  
+   - `docs/agent/README.md` (FAQ and implementation tracing path)
+5. Use API-based lookup when tracing from API  
+   - `docs/api-reference.md` (2.2)
 
-## 9. よくある初期トラブル
+## 9. Common Initial Issues
 
-### リポジトリ未設定（GitHub）
+### Repository Not Configured (GitHub)
 
-- Start ページの repo manager から既存 repo を選択、または新規作成
-- `REPO_MODE=git` の場合は `REPO_URL` と `GITHUB_OWNER/REPO` が必要
+- Select existing repo or create new one from Start page repo manager
+- For `REPO_MODE=git`, need `REPO_URL` and `GITHUB_OWNER/REPO`
 
-### 認証警告（Claude auth warning）への対処
+### Handling Claude Auth Warning
 
-- host 実行: `claude /login` を再実行
-- sandbox 実行: host の認証ディレクトリがマウントされることを確認
+- Host execution: rerun `claude /login`
+- Sandbox execution: confirm host auth dir is mounted
 
-### 起動時に Planner が起動しない（preflight）
+### Planner Not Starting (Preflight)
 
-- backlog 優先の正常動作です
-- Issue/PR/ローカル backlog が解消されると再計画対象になります
+- Normal behavior with backlog priority
+- Becomes replan target when Issue/PR/local backlog is cleared

--- a/docs/idea.md
+++ b/docs/idea.md
@@ -1,35 +1,35 @@
-# 今後のアイデア
+# Future Ideas
 
 ## 1. Planner Fallback Layer
 
-- inspection が連続失敗したときに使える optional な `degraded planning` mode を追加する
-- planning を hard abort せず、最小安全 task を生成する
+- Add optional `degraded planning` mode for continuous inspection failures
+- Avoid hard abort of planning; generate minimal safe tasks
 
 ## 2. Recovery Explainability
 
-- task 単位の状態遷移を示す timeline panel を第一級機能として追加する
-- reason の変化（`quota_wait -> queued -> running -> awaiting_judge`）を可視化する
+- Add task-level state transition timeline panel as first-class feature
+- Visualize reason changes (`quota_wait -> queued -> running -> awaiting_judge`)
 
 ## 3. Judge Throughput Controls
 
-- awaiting backlog の増減傾向に応じて judge 数を動的スケーリングする
-- 最も古い blocked 親 task を持つ PR を優先評価する
+- Dynamically scale judge count based on awaiting backlog trend
+- Prioritize evaluation of PRs with oldest blocked parent task
 
 ## 4. Retry Policy Profiles
 
-- profile ベースの retry policy（`aggressive`, `balanced`, `cost-save`）を追加する
-- config row ごとに project 単位 override を許可する
+- Add profile-based retry policy (`aggressive`, `balanced`, `cost-save`)
+- Allow project-level override per config row
 
 ## 5. Safety Hardening
 
-- 想定外 external path への preflight permission check を強化する
-- worker instruction へ path を渡す前に明示的 validation を追加する
+- Strengthen preflight permission check for unexpected external paths
+- Add explicit validation before passing paths to worker instructions
 
-## 6. 共通逆引き導線（状態語彙 -> 遷移 -> 担当 -> 実装、アイデア評価時）
+## 6. Common Lookup Path (State Vocabulary -> Transition -> Owner -> Implementation, When Evaluating Ideas)
 
-改善案を試すときは、影響の有無を状態語彙 -> 遷移 -> 担当 -> 実装の順で確認すると比較しやすくなります。
+When trying improvements, checking impact in order state vocabulary -> transition -> owner -> implementation helps compare:
 
-1. `docs/state-model.md`（状態語彙がどう変わるか）
-2. `docs/flow.md`（遷移と回復経路にどんな差分が出るか）
-3. `docs/operations.md`（運用時の API 確認手順に変更が要るか）
-4. `docs/agent/README.md`（担当 agent と実装責務に影響があるか）
+1. `docs/state-model.md` (how state vocabulary changes)
+2. `docs/flow.md` (what transition/recovery differences appear)
+3. `docs/operations.md` (whether API check procedures need updates)
+4. `docs/agent/README.md` (impact on owning agent and implementation responsibilities)

--- a/docs/mode.md
+++ b/docs/mode.md
@@ -1,8 +1,8 @@
-# 運用モード
+# Operation Modes
 
-openTiger の挙動は、リポジトリモード / 判定モード / 実行環境 の組み合わせで制御されます。
+openTiger behavior is controlled by the combination of repository mode / judge mode / execution environment.
 
-関連:
+Related:
 
 - `docs/config.md`
 - `docs/state-model.md`
@@ -13,125 +13,125 @@ openTiger の挙動は、リポジトリモード / 判定モード / 実行環�
 - `docs/agent/dispatcher.md`
 - `docs/agent/judge.md`
 
-### 共通逆引き導線（状態語彙 -> 遷移 -> 担当 -> 実装、モード設定から入る場合）
+### Common Lookup Path (State Vocabulary -> Transition -> Owner -> Implementation, When Entering from Mode Config)
 
-モード設定を確認したあとに停滞を追う場合は、状態語彙 -> 遷移 -> 担当 -> 実装の順で確認してください。
+When tracing stalls from mode config, check in order: state vocabulary -> transition -> owner -> implementation.
 
-1. `docs/state-model.md`（状態語彙の確認）
-2. `docs/flow.md`（遷移と回復経路）
-3. `docs/operations.md`（API 確認手順と運用ショートカット）
-4. `docs/agent/README.md`（担当 agent と実装追跡ルート）
+1. `docs/state-model.md` (state vocabulary)
+2. `docs/flow.md` (transitions and recovery paths)
+3. `docs/operations.md` (API procedures and operation shortcuts)
+4. `docs/agent/README.md` (owning agent and implementation tracing path)
 
-## 1. リポジトリモード（`REPO_MODE`）
+## 1. Repository Mode (`REPO_MODE`)
 
 ### `git`
 
-- clone/push/PR ベースの運用
-- judge は主に PR artifact を評価
+- Clone/push/PR-based operation
+- Judge mainly evaluates PR artifacts
 
-必須設定:
+Required config:
 
 - `REPO_URL`
 - `BASE_BRANCH`
-- `GITHUB_AUTH_MODE`（`gh` または `token`、既定: `gh`）
+- `GITHUB_AUTH_MODE` (`gh` or `token`; default: `gh`)
 - `GITHUB_OWNER`
 - `GITHUB_REPO`
 
-補足:
+Note:
 
-- `GITHUB_AUTH_MODE=gh` の場合は GitHub CLI（`gh auth login`）で認証します。
-- `GITHUB_AUTH_MODE=token` の場合は `GITHUB_TOKEN` を設定します。
+- With `GITHUB_AUTH_MODE=gh`, authenticate via GitHub CLI (`gh auth login`)
+- With `GITHUB_AUTH_MODE=token`, set `GITHUB_TOKEN`
 
 ### `local`
 
-- ローカルリポジトリ + worktree ベースの運用
-- remote PR 作成は不要
+- Local repository + worktree-based operation
+- No remote PR creation
 
-必須設定:
+Required config:
 
 - `LOCAL_REPO_PATH`
 - `LOCAL_WORKTREE_ROOT`
 - `BASE_BRANCH`
 
-## 2. 判定モード（`JUDGE_MODE`）
+## 2. Judge Mode (`JUDGE_MODE`)
 
-- `git`: PR review 経路を強制
-- `local`: ローカル差分経路を強制
-- `auto`: リポジトリモードに追従
+- `git`: force PR review path
+- `local`: force local diff path
+- `auto`: follow repository mode
 
-補足:
+Note:
 
-- `JUDGE_MODE` は環境変数で決まる runtime option であり、`system_config` の DB キーではありません。
+- `JUDGE_MODE` is a runtime option from env, not a `system_config` DB key.
 
-主要フラグ:
+Main flags:
 
 - `JUDGE_MERGE_ON_APPROVE`
 - `JUDGE_REQUEUE_ON_NON_APPROVE`
 
-## 3. 実行環境と起動モード
+## 3. Execution Environment and Launch Mode
 
-ユーザー向け設定キーは `EXECUTION_ENVIRONMENT`（`system_config`）です。
+User-facing key is `EXECUTION_ENVIRONMENT` (in `system_config`).
 
-内部の起動モードは次のように導出されます。
+Internal launch mode is derived as:
 
 - `host` -> `LAUNCH_MODE=process`
 - `sandbox` -> `LAUNCH_MODE=docker`
 
-実行時の詳細（Docker image/network、sandbox 認証、トラブルシュート）は `docs/execution-mode.md` を参照してください。
+For runtime details (Docker image/network, sandbox auth, troubleshooting), see `docs/execution-mode.md`.
 
-`LAUNCH_MODE` は runtime の内部値のため、通常は直接設定する必要はありません。
+`LAUNCH_MODE` is internal; you normally don't set it directly.
 
-### `process`（host）
+### `process` (host)
 
-- 常駐 agent が queue job を消化
-- 回復速度と運用可視性を優先
+- Resident agents consume queue jobs
+- Prioritizes recovery speed and operational visibility
 
-### `docker`（sandbox）
+### `docker` (sandbox)
 
-- task 単位の container 分離
-- 分離要件が厳しい環境で有効
+- Per-task container isolation
+- Useful when isolation requirements are strict
 
-## 4. スケーリングルール
+## 4. Scaling Rules
 
-- planner は API/system ロジックで 1 process に固定
-- worker/tester/docser/judge の数は設定可能
-- dispatcher の slot 制御は busy な実行 role（`worker/tester/docser`）のみを計数
+- Planner is fixed at 1 process by API/system logic
+- worker/tester/docser/judge counts are configurable
+- Dispatcher slot control counts only busy execution roles (`worker`/`tester`/`docser`)
 
-実装責務:
+Implementation responsibility:
 
-- slot 制御/配布判定: `docs/agent/dispatcher.md`
-- approve/rework 判定: `docs/agent/judge.md`
+- Slot control/dispatch: `docs/agent/dispatcher.md`
+- Approve/rework decisions: `docs/agent/judge.md`
 
-## 5. 想定される起動時挙動
+## 5. Expected Startup Behavior
 
-`/system/preflight` は意図的に planner をスキップする場合があります。
+`/system/preflight` may intentionally skip planner.
 
-典型例:
+Examples:
 
-- issue backlog がある -> issue task を先に作成/継続
-- open PR または `awaiting_judge` backlog がある -> judge を先行起動
-- planner は backlog が解消され、かつ requirement がある場合のみ起動
+- Issue backlog exists -> create/continue issue tasks first
+- Open PR or `awaiting_judge` backlog exists -> start Judge first
+- Planner starts only when backlog is cleared and requirement exists
 
-## 6. リトライ / 回復制御
+## 6. Retry / Recovery Control
 
-主要ノブ:
+Main knobs:
 
 - `FAILED_TASK_RETRY_COOLDOWN_MS`
 - `BLOCKED_TASK_RETRY_COOLDOWN_MS`
-- `FAILED_TASK_MAX_RETRY_COUNT`（`-1` は global retry budget 無制限）
+- `FAILED_TASK_MAX_RETRY_COUNT` (`-1` = global retry budget unlimited)
 - `DISPATCH_RETRY_DELAY_MS`
 - `SYSTEM_PROCESS_AUTO_RESTART*`
 
-キュー/ロック回復ノブ:
+Queue/lock recovery knobs:
 
 - `TASK_QUEUE_LOCK_DURATION_MS`
 - `TASK_QUEUE_STALLED_INTERVAL_MS`
 - `TASK_QUEUE_MAX_STALLED_COUNT`
 
-## 7. quota 運用設定
+## 7. Quota Operation Config
 
 - `OPENCODE_WAIT_ON_QUOTA`
 - `OPENCODE_QUOTA_RETRY_DELAY_MS`
 - `OPENCODE_MAX_QUOTA_WAITS`
 
-現在の task レベル挙動は、`blocked(quota_wait)` と cycle の cooldown requeue により収束させる設計です。
+Current task-level behavior converges via `blocked(quota_wait)` and cycle cooldown requeue.

--- a/docs/nonhumanoriented.md
+++ b/docs/nonhumanoriented.md
@@ -1,95 +1,95 @@
-# 非人手前提の運用原則
+# Non-Human-First Operation Principles
 
-## 1. 目的
+## 1. Purpose
 
-人手の常時監視なしで、自律的に進捗し続けることを目的とします。
+To continuously make progress autonomously without constant human monitoring.
 
-実運用での定義:
+Practical definition:
 
-- 無言の deadlock を作らない
-- 状態変化のない同一ステップ無限ループを作らない
-- 反復失敗は別の recovery 経路へ必ず変換する
+- No silent deadlocks
+- No infinite loops on the same step with no state change
+- Repeated failures always converted to a different recovery path
 
-完了ポリシー:
+Completion policy:
 
-- 外部条件を含む全ケースでの完了保証は前提にしない
-- システムが意図的に停止し続けないことを保証する
-- 進捗が劣化したときは recovery 状態遷移で戦略を強制的に切り替える
+- Don't assume completion guarantee for all cases including external conditions
+- Guarantee that the system does not intentionally stay stopped
+- When progress degrades, force strategy change via recovery state transition
 
-## 2. コア原則
+## 2. Core Principles
 
-- 初回完全成功より Recovery-first
-- 冪等な制御点（lease / run claim / dedupe signature）
-- backlog-first 起動（新規生成より既存 backlog 解消を優先）
-- 機械回復可能な明示 blocked reason
+- Recovery-first over first-attempt success
+- Idempotent control points (lease / run claim / dedupe signature)
+- Backlog-first startup (prioritize consuming existing backlog over new generation)
+- Explicit blocked reasons that are machine-recoverable
 
-## 3. 停滞防止メカニズム
+## 3. Stall-Prevention Mechanisms
 
-### 3.1 Lease と Runtime Lock の規律
+### 3.1 Lease and Runtime Lock Discipline
 
-- task lease で重複 dispatch を防止
-- runtime lock で重複実行を防止
-- dangling / expired / orphaned lease を継続的に回収
+- Task lease prevents duplicate dispatch
+- Runtime lock prevents duplicate execution
+- Continuously reclaim dangling / expired / orphaned leases
 
-### 3.2 Judge の冪等性
+### 3.2 Judge Idempotency
 
-- 未判定の成功 run だけを対象化
-- claim 済み run は同時二重判定できない
+- Only unjudged successful runs are processed
+- Claimed runs cannot be double-judged
 
-### 3.3 Halt State ではなく Recovery State を使う
+### 3.3 Use Recovery State Instead of Halt State
 
 - `awaiting_judge`
 - `quota_wait`
 - `needs_rework`
 
-planner の issue-link 順序制御に使う runtime blocked state:
+Runtime blocked state for planner issue-link ordering:
 
 - `issue_linking`
 
-状態を放棄せず、回復可能な状態へ変換します。
+Convert state to recoverable, never abandon it.
 
-### 3.4 適応的 Escalation
+### 3.4 Adaptive Escalation
 
-- 同一 failure signature の反復で rework/autofix へ昇格
-- merge-conflict 後の approve は可能なら conflict autofix task へ分岐
+- Escalate to rework/autofix on repeated same failure signature
+- On merge conflict after approve, branch to conflict autofix task when possible
 
-### 3.5 Event-Driven な進捗回復
+### 3.5 Event-Driven Progress Recovery
 
-回復切り替えは固定時間トリガーではなく event-driven で実行します。
+Recovery switch is event-driven, not fixed-time triggered:
 
-- 同一失敗シグネチャ反復 -> `needs_rework` / rework split
-- non-approve circuit breaker -> autofix path
-- quota failure -> `quota_wait` -> cooldown requeue
-- judge 可能 run 欠落 -> `awaiting_judge` run context 復元
+- Repeated same failure signature -> `needs_rework` / rework split
+- Non-approve circuit breaker -> autofix path
+- Quota failure -> `quota_wait` -> cooldown requeue
+- Missing judgable run -> restore `awaiting_judge` run context
 
-## 4. Quota に対する考え方
+## 4. Quota Philosophy
 
-quota 圧は終端失敗ではなく、回復可能な外部圧として扱います。
+Treat quota pressure as recoverable external pressure, not terminal failure.
 
-- 単発 attempt は速やかに失敗してよい
-- task は明示理由（`quota_wait`）で待機させる
-- リソース回復まで cooldown retry を継続する
+- Single attempt may fail quickly
+- Task waits with explicit reason (`quota_wait`)
+- Continue cooldown retry until resources recover
 
-## 5. 可観測性要件
+## 5. Observability Requirements
 
-運用者は試行結果だけでなく、次の進行意図を観測できる必要があります。
+Operators must observe not only trial results but also intended next steps:
 
-- run レベル失敗
-- task レベルの次回 retry reason/time
-- preflight が返す backlog gate 理由
+- Run-level failure
+- Task-level next retry reason/time
+- Backlog gate reason returned by preflight
 
 ## 6. Non-Goals
 
-- 回復性を犠牲にした初回成功率の最大化
-- 安全な並列性があるのに厳密逐次処理へ固定
-- 手動限定の recovery フロー
-- 固定分 watchdog だけに依存した回復設計
+- Maximizing first-attempt success at cost of recoverability
+- Fixed strict sequential processing when safe concurrency exists
+- Recovery flows that require manual intervention only
+- Recovery design that relies only on fixed-interval watchdog
 
-## 7. 共通逆引き導線（状態語彙 -> 遷移 -> 担当 -> 実装）
+## 7. Common Lookup Path (State Vocabulary -> Transition -> Owner -> Implementation)
 
-このページは設計思想を示すため、実際の切り分けは状態語彙 -> 遷移 -> 担当 -> 実装の順で確認します。
+This page describes design principles; for actual triage, follow state vocabulary -> transition -> owner -> implementation.
 
-1. `docs/state-model.md`（状態語彙）
-2. `docs/flow.md`（遷移と回復経路）
-3. `docs/operations.md`（API 手順と運用ショートカット）
-4. `docs/agent/README.md`（担当 agent と実装追跡）
+1. `docs/state-model.md` (state vocabulary)
+2. `docs/flow.md` (transitions and recovery paths)
+3. `docs/operations.md` (API procedures and operation shortcuts)
+4. `docs/agent/README.md` (owning agent and implementation tracing)

--- a/docs/requirement.md
+++ b/docs/requirement.md
@@ -1,58 +1,58 @@
-# ゴール
+# Goal
 
-QEMU（qmenu）で起動し、kernel console を提供し、自動検証付きで安全に反復開発できる  
-最小かつ拡張可能な RISC-V OS baseline を構築する。
+Build a minimal, extensible RISC-V OS baseline that boots under QEMU (qemu-system-riscv64),  
+provides a kernel console, and enables safe iterative development with automated verification.
 
-## 背景
+## Background
 
-openTiger による継続的な自律開発フローで RISC-V OS を育てることを想定する。  
-自律反復の安定化のため、最初のマイルストーンはフル機能 OS ではなく、  
-小さく検証可能な kernel baseline に限定する。
+Intended for growing a RISC-V OS via openTiger's continuous autonomous development flow.  
+To stabilize autonomous iteration, the first milestone is limited to a small, verifiable kernel baseline,  
+not a full-featured OS.
 
-## 制約
+## Constraints
 
-- 既存リポジトリで採用済みの言語/ツールチェーン選定を維持する
-- 対象は RISC-V 64-bit 仮想環境（`qemu-system-riscv64`, `virt` machine）
-- boot/kernel 挙動は CI/ローカル自動検証で扱える程度に deterministic を保つ
-- 厳密に必要な場合を除き、重い外部 runtime dependency を追加しない
-- 一括大改修より、段階的でテスト可能な小さな slice を優先する
+- Keep existing language and toolchain choices in the repo
+- Target RISC-V 64-bit virtual environment (`qemu-system-riscv64`, `virt` machine)
+- Boot/kernel behavior remains deterministic enough for CI/local automated verification
+- Avoid heavy external runtime dependencies except when strictly necessary
+- Prefer incremental, testable slices over large one-off changes
 
-## 受け入れ基準
+## Acceptance Criteria
 
-- [ ] プロジェクト標準 build command で kernel image を生成できる
-- [ ] QEMU 起動で kernel entry 到達と serial console への boot banner 出力を確認できる
-- [ ] UART console 入出力が最低限 line-based command で動作する
-- [ ] trap/exception handler が配線され、unexpected trap の cause 情報を log 出力できる
-- [ ] timer interrupt が有効化され、周期 tick を log で少なくとも 1 回確認できる
-- [ ] 4KiB page 単位の simple physical page allocator があり、allocation/free の基本テストが通る
-- [ ] 基本 kernel task 実行（少なくとも 2 task の round-robin scheduling）ができる
-- [ ] 最小 kernel command interface（`help`, `echo`, `meminfo`）がある
-- [ ] QEMU boot と log marker 検証を行う自動 smoke test が少なくとも 1 本ある
-- [ ] 実現可能な範囲で kernel 主要変更に unit/integration test を付与し、必須 checks が通る
+- [ ] Kernel image can be built with project-standard build command
+- [ ] Boot banner appears on serial console when booting with QEMU
+- [ ] UART console I/O works for minimal line-based commands
+- [ ] Trap/exception handlers are wired; unexpected trap cause info can be logged
+- [ ] Timer interrupt enabled; at least one periodic tick visible in logs
+- [ ] Simple physical page allocator (4KiB pages) with basic allocation/free tests
+- [ ] Basic kernel task execution (at least 2 tasks round-robin scheduled)
+- [ ] Minimal kernel command interface (`help`, `echo`, `meminfo`)
+- [ ] At least one automated smoke test that runs QEMU boot and verifies log markers
+- [ ] Unit/integration tests for major kernel changes where feasible; required checks pass
 
-## スコープ
+## Scope
 
-## 対象範囲（In Scope）
+## In Scope
 
-- RISC-V `virt` machine 向け boot path と early initialization
-- UART 経由の kernel console
-- trap/interrupt 初期化と timer tick 処理
-- 基本的な physical memory page allocator
-- kernel task 用 minimal scheduler 基盤
-- serial console 上の最小 command interface
-- ローカル/CI で再現可能な build/test script
-- setup/run command に関する必須ドキュメント更新
+- Boot path and early initialization for RISC-V `virt` machine
+- Kernel console via UART
+- Trap/interrupt init and timer tick handling
+- Basic physical memory page allocator
+- Minimal scheduler for kernel tasks
+- Minimal command interface on serial console
+- Build/test scripts reproducible in local/CI
+- Required documentation updates for setup/run commands
 
-## 対象外（Out of Scope）
+## Out of Scope
 
-- user-space process 分離を含む完全な virtual memory subsystem
-- 完全な POSIX 互換
-- 最小 stub を超える file system 実装
-- network stack
-- multi-core SMP scheduling
-- baseline correctness を超える security hardening
+- Full virtual memory subsystem including user-space process isolation
+- Full POSIX compatibility
+- File system beyond minimal stub
+- Network stack
+- Multi-core SMP scheduling
+- Security hardening beyond baseline correctness
 
-## 許可パス（Allowed Paths）
+## Allowed Paths
 
 - `arch/riscv/**`
 - `boot/**`
@@ -66,19 +66,19 @@ openTiger による継続的な自律開発フローで RISC-V OS を育てる�
 - `README.md`
 - `Makefile`
 
-## リスク評価
+## Risk Assessment
 
 | Risk | Impact | Mitigation |
 | --- | --- | --- |
-| QEMU 上で boot sequence が不安定になり非決定的失敗が起きる | high | 初期 boot log を明示的に保ち、boot marker 用 smoke test を追加する |
-| Trap/interrupt 設定ミスで後続 kernel 実装が詰まる | high | trap setup を段階的に実装し、分離テストで早期検証する |
-| Scheduler bug が starvation/deadlock を隠れ発生させる | medium | 最小 round-robin から開始し deterministic task test を追加する |
-| Memory allocator 破損で障害が連鎖する | high | allocator invariant と targeted allocation/free test を追加する |
-| Scope 拡張で自律反復速度が落ちる | medium | 本マイルストーンを baseline に固定し高度機能は後続へ送る |
+| Boot sequence unstable on QEMU, non-deterministic failures | high | Keep explicit boot logs; add smoke test for boot markers |
+| Trap/interrupt misconfiguration blocks later kernel work | high | Implement trap setup incrementally; validate with isolated tests |
+| Scheduler bugs hide starvation/deadlock | medium | Start with minimal round-robin; add deterministic task tests |
+| Memory allocator corruption cascades failures | high | Add allocator invariant and allocation/free tests |
+| Scope creep slows autonomous iteration | medium | Lock this milestone as baseline; defer advanced features |
 
-## 補足
+## Notes
 
-milestone-first 戦略で進める:
+Milestone-first strategy:
 
 1. boot + console
 2. trap/timer
@@ -87,14 +87,14 @@ milestone-first 戦略で進める:
 5. command interface
 6. smoke tests + docs
 
-openTiger 運用では、非対話で安定実行できる verification command を必ず用意する。  
-（例: headless QEMU 実行 + log marker 検証の smoke test script）
+For openTiger operation, always provide non-interactive, stable verification commands.  
+(e.g. headless QEMU run + smoke script that verifies log markers)
 
-## 共通逆引き導線（状態語彙 -> 遷移 -> 担当 -> 実装、要件更新後）
+## Common Lookup Path (State Vocabulary -> Transition -> Owner -> Implementation, After Requirement Update)
 
-要件を更新した後に停滞や想定外挙動が出た場合は、状態語彙 -> 遷移 -> 担当 -> 実装の順で確認する。
+If stalls or unexpected behavior appear after requirement updates, follow: state vocabulary -> transition -> owner -> implementation.
 
-1. `docs/state-model.md`（状態語彙）
-2. `docs/flow.md`（遷移と回復経路）
-3. `docs/operations.md`（API 手順と運用ショートカット）
-4. `docs/agent/README.md`（担当 agent と実装追跡）
+1. `docs/state-model.md` (state vocabulary)
+2. `docs/flow.md` (transitions and recovery paths)
+3. `docs/operations.md` (API procedures and operation shortcuts)
+4. `docs/agent/README.md` (owning agent and implementation tracing)


### PR DESCRIPTION
Synchronize documentation with the source code and restructure it to improve clarity and completeness for new OSS users.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a1ca29a6-2f9b-4fc6-abe4-244c37810e17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1ca29a6-2f9b-4fc6-abe4-244c37810e17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications; risk is limited to potential confusion from wording inaccuracies or outdated references.
> 
> **Overview**
> Reworks the top-level `README.md` and `docs/README.md` into a clearer onboarding/operations entrypoint, including a first-time checklist, architecture overview, and explicit “state vocabulary -> transition -> owner -> implementation” lookup paths.
> 
> Adds a comprehensive OSS docs set covering API usage (`docs/api-reference.md`), operations/runbooks (`docs/operations.md`), architecture (`docs/architecture.md`), state model (`docs/state-model.md`), startup/replan rules (`docs/startup-patterns.md`), verification strategy (`docs/verification.md`), and per-agent specifications under `docs/agent/` (including new `dispatcher` and `cycle-manager` specs), while updating existing docs (`config`, `mode`, `execution-mode`, `policy-recovery`, and agent pages) to align terminology and cross-link references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f681ad1b106dfd5da1f84e95c7294c5205d9c2ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->